### PR TITLE
Help mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Better plugin error handling and add config validation
 - Add alias support for data adapter config (ref variant)
+- **Breaking change**: Modules are now wrapped with a `position: relative` container. Any module that had elements depending on the parent layout, such as flex or `height: 100%` could theoretically break. As a workaround, a new method called `getWrapperStyle` was added to the module definition.
 
 # v1.0.0-beta.5
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Alethio CMS is a front-end content management system designed for real-time and 
 - [Deployment with plugins](#deployment-with-plugins)
     - [Option 1. Install the plugins in the base app at build-time](#option-1-install-the-plugins-in-the-base-app-at-build-time)
     - [Option 2. Load the plugins from an external CDN](#option-2-load-the-plugins-from-an-external-cdn)
+- [Help System](#help-system)
 - [CMS Development](#cms-development)
 
 <!-- /TOC -->
@@ -1004,6 +1005,68 @@ We can first install the plugins in a temporary folder:
 `$ acp install --target /tmp/plugins <plugin_npm_package_or_local_folder>`
 
 And then sync the target folder structure with the external CDN via preferred method.
+
+## Help System
+
+Help content can be defined per module by adding a `getHelpComponent` method in the module definition.
+
+Example:
+```jsx
+let module = {
+    //...
+    getHelpComponent: () => ({ translation, /* ... */ }) => translation.get("my.help.content.key")
+}
+```
+
+Help can be displayed by turning on/off a special "help mode". In help mode, the user can hover a module and if that module has help, it will be highlighted with a border and "help" mouse cursor. When clicked, the help content for that module is rendered with a user-defined component. Help mode can be controlled from the callback which is passed to `Cms` component as child.
+
+Example:
+```jsx
+import React from "react";
+import ReactDOM from "react-dom";
+import { Observer } from "mobx-react";
+import { Cms } from "@alethio/cms";
+import { Layer } from "@alethio/ui/lib/overlay/Layer";
+import { Mask } from "@alethio/ui/lib/overlay/Mask";
+import { HelpIcon } from "@alethio/ui/lib/icon/HelpIcon";
+import { Toolbar } from "@alethio/ui/lib/layout/toolbar/Toolbar";
+import { ToolbarItem } from "@alethio/ui/lib/layout/toolbar/ToolbarItem";
+import { ToolbarIconButton } from "@alethio/ui/lib/layout/toolbar/ToolbarIconButton";
+import { Button } from "@alethio/ui/lib/control/Button";
+
+export class App extends React.Component {
+    // ...
+    render() {
+        return <Cms
+            // ...
+            HelpComponent={({ children, module, onRequestClose }) => ReactDOM.createPortal(<>
+                <Mask />
+                <Layer>
+                    {children}
+                    <Button onClick={onRequestClose}>Got it</Button>
+                </Layer>
+            </>, document.body)}
+        >{ ({ slots, routes, helpMode }) => {
+            return <div>
+                <Toolbar>
+                    { /* Observer prevents the whole page from reacting whenever helpMode is toggled */}
+                    <Observer>{() =>
+                        <ToolbarItem title={helpMode.isActive() ? "Toggle off help mode" : "Toggle on help mode"}>
+                            <ToolbarIconButton
+                                active={helpMode.isActive()}
+                                Icon={HelpIcon}
+                                onClick={() => helpMode.toggle()} />
+                        </ToolbarItem>
+                    }</Observer>
+                    {slots && slots["toolbar"]}
+                </Toolbar>
+                { /* ... */ }
+                <div>{ routes }</div>
+            </div>;
+        }}</Cms>;
+    }
+}
+```
 
 ## CMS Development
 

--- a/doc/adr/0002-highlight-modules.md
+++ b/doc/adr/0002-highlight-modules.md
@@ -1,0 +1,49 @@
+# Highlight modules in help mode
+
+## Context
+
+In help mode, we needed to highlight modules to show that they have help associated with them.
+
+### Requirements
+1. Highlight each module with a dashed border + "help" mouse pointer
+2. Mask its contents to block user interactions with the module itself. Clicking on a mask opens the help frame.
+3. Modules without help should not be clickable. If nested inside another module, we'll pass this responsibility to the parent module (otherwise the parent might have help and we'll block part of it with the mask for the child).
+
+### Invariants
+1. Module content is unknown and may contain one or more elements
+2. Module may break out of its parent container (e.g. account accordion with negative margin)
+3. Module layout is unknown (we might have flex-grow - e.g. sidebar block list, absolute position etc.)
+4. There are layout dependencies between parent and child (e.g. flex, grid, height: 100%, position: absolute)
+
+## Problem statement
+
+To implement the requirements, we need to solve two generic sub-problems:
+
+**Sub-problem 1**: Apply highlighting to an element
+
+Considered options:
+- Option 1: Apply inline styles (border/outline) to the element itself
+- Option 2: Wrap the element with another element on which we add the above styles
+- Option 3: Create a proxy element that we manually position on top of the target element
+
+**Sub-Problem 2**: Mask an element and intercept interactions
+
+Considered options:
+- ~~Option 1: Use a capture-phase click handler with stopPropagation => doesn't appear to work at all~~
+- Option 2: Create a mask element as a child of target element with `position: absolute`; target receives `position: relative`. Variant: Wrap the target with a div and place the mask as a sibling of the target.
+- Option 3: Create a separate mask element in body and position it on top of target element and above everything else. Need to calculate z-indexes manually for each element based on target position on the page.
+
+## Considered options
+
+Options that satisfy both sub-problems:
+- ~~Option 1: Mask element as child of target, apply `position: relative` directly to target~~ *=> doesn't work, React can't access DOM elements inside function components*
+- Option 2: Wrap target with an element that has `position: relative` and add mask as sibling to the target module. Allow module author to define wrapper CSS styles, to prevent breaking layout. Wrapper is still going to be a breaking change.
+- Option 3: Mask element in body with manual position/sync
+
+## Decision outcome
+
+Chose `Option 2` because
+
+* `Option 1` is only possible if an explicit target is given by module author for every single module. Inconvenient and also error-prone because we alter styles on elements that we don't control. Very hackish to implement.
+
+* `Option 3` is too complex and we still need an explicit target regardless of how many elements are in the module.

--- a/doc/adr/index.md
+++ b/doc/adr/index.md
@@ -1,5 +1,6 @@
 # Architectural Decision Log
 
 - [ADR-0001](0001-define-inline-plugins.md) - Define inline plugins with dynamic imports
+- [ADR-0002](0002-highlight-modules.md) - Highlight modules in help mode
 
 Inspired by https://github.com/joelparkerhenderson/architecture_decision_record and [MADR](https://github.com/adr/madr/blob/master/docs/adr/index.md)

--- a/package-lock.json
+++ b/package-lock.json
@@ -917,8 +917,9 @@
       }
     },
     "plugin-api": {
-      "version": "github:Alethio/cms-plugin-api#a38855121c5f8a706488a3c3a93a092420a2ac30",
-      "from": "github:Alethio/cms-plugin-api#help-mode",
+      "version": "npm:@alethio/cms-plugin-api@1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@alethio/cms-plugin-api/-/cms-plugin-api-1.0.0-beta.5.tgz",
+      "integrity": "sha512-6t2Fo7Fmo861X9Ej6N8c5k6CvAtUVEUgSUyluruF3nBKyoYruzt4IcN4zgUbD0nkZwI5CTLJq1bzuOLTrqBiYw==",
       "dev": true,
       "requires": {
         "@alethio/ui": "^1.0.0-beta.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -917,9 +917,8 @@
       }
     },
     "plugin-api": {
-      "version": "npm:@alethio/cms-plugin-api@1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@alethio/cms-plugin-api/-/cms-plugin-api-1.0.0-beta.4.tgz",
-      "integrity": "sha512-vJYta1cZKQCa/xz6K+Z2hejgNxsopS/VM/eqjIk2h435oWCoXGbnpjanhg87Oqzs4X6lhbCAL4WBhHL55D3Clw==",
+      "version": "github:Alethio/cms-plugin-api#8da9ef7597f8956d7c8c0ff05547dd057ad04b39",
+      "from": "github:Alethio/cms-plugin-api#help-mode",
       "dev": true,
       "requires": {
         "@alethio/ui": "^1.0.0-beta.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1305,6 +1305,15 @@
         "tslib": "^1.8.1"
       }
     },
+    "ttypescript": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.7.tgz",
+      "integrity": "sha512-qloW8S60+xWVC2bQWldYQfESNFkIgDL5/M+vAOOsuLJ1pQu0SG2vQx5DNJO2nlwSrHxD8cDuF2sVDXg6v3GG3Q==",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.9.0"
+      }
+    },
     "typed-styles": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -917,7 +917,7 @@
       }
     },
     "plugin-api": {
-      "version": "github:Alethio/cms-plugin-api#8da9ef7597f8956d7c8c0ff05547dd057ad04b39",
+      "version": "github:Alethio/cms-plugin-api#a38855121c5f8a706488a3c3a93a092420a2ac30",
       "from": "github:Alethio/cms-plugin-api#help-mode",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "husky": "^1.3.1",
     "mobx": "^5.9.4",
     "mobx-react": "^5.4.3",
-    "plugin-api": "github:Alethio/cms-plugin-api#help-mode",
+    "plugin-api": "npm:@alethio/cms-plugin-api@^1.0.0-beta.5",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "rimraf": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "husky": "^1.3.1",
     "mobx": "^5.9.4",
     "mobx-react": "^5.4.3",
-    "plugin-api": "npm:@alethio/cms-plugin-api@^1.0.0-beta.4",
+    "plugin-api": "github:Alethio/cms-plugin-api#help-mode",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "rimraf": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "npm run clean && tsc -p . && npm run lint",
+    "build": "npm run clean && ttsc -p . && npm run lint",
     "clean": "rimraf ./dist",
-    "watch": "tsc -p . --watch",
+    "watch": "ttsc -p . --watch",
     "lint": "tslint -p ./tslint.prod.json",
     "prepare": "npm run build"
   },
@@ -35,6 +35,7 @@
     "styled-components": "^3.4.2",
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
+    "ttypescript": "^1.5.7",
     "typescript": "^3.4.1",
     "typescript-plugin-styled-components": "^1.0.0",
     "typescript-styled-plugin": "^0.10.0",

--- a/src/IContext.ts
+++ b/src/IContext.ts
@@ -1,8 +1,12 @@
 import { IModule } from "./IModule";
 import { IContextDef } from "plugin-api/IContextDef";
+import { IPage } from "./IPage";
+
 export interface IContext<TParentContext, TChildContext> {
     pluginUri: string;
+    uri: string;
     def: IContextDef<TParentContext, TChildContext>;
     pageCritical?: boolean;
+    parent?: IPage<any, unknown> | IModule<unknown, unknown> | IContext<unknown, unknown>;
     children: IModule<any, TChildContext, any>[];
 }

--- a/src/IModule.ts
+++ b/src/IModule.ts
@@ -1,11 +1,15 @@
 import { IModuleDef } from "plugin-api/IModuleDef";
+import { IPage } from "./IPage";
+import { IContext } from "./IContext";
 
 export interface IModule<TContentProps, TContext, TSlotType = undefined> {
     pluginUri: string;
+    uri: string;
     uuid: string;
     def: IModuleDef<TContentProps, TContext, TSlotType>;
     pageCritical?: boolean;
     options?: unknown;
+    parent?: IPage<any, unknown> | IModule<unknown, unknown> | IContext<unknown, unknown>;
     children?: TSlotType extends string | number ?
         Record<TSlotType, IModule<any, TContext, any>[]> :
         undefined;

--- a/src/component/Cms.tsx
+++ b/src/component/Cms.tsx
@@ -12,6 +12,7 @@ import { PageRenderer, IRootPageProps } from "./PageRenderer";
 import { ThemeContext } from "../ThemeContext";
 import { ThemeProvider as StyledThemeProvider } from "@alethio/ui/lib/styled-components";
 import { IInlinePlugin } from "../IInlinePlugin";
+import { IHelpComponentProps } from "./IHelpComponentProps";
 
 export interface ICmsProps<TRootSlotType extends string> {
     /** An object that will log errors and messages from the CMS (e.g. `logger={console}`) */
@@ -27,7 +28,7 @@ export interface ICmsProps<TRootSlotType extends string> {
      * **IMPORTANT**: When using inline plugins, make sure to add the "plugin-api" module as an external
      * in your webpack config, if making use of it:
      *
-     * ```ts
+     * ```
      * externals: [
      *       function(context, request, callback) {
      *           if (/^plugin-api\/.+$/.test(request)) {
@@ -45,6 +46,8 @@ export interface ICmsProps<TRootSlotType extends string> {
     locale: string;
     /** A fallback default locale for the plugins that don't support the currently selected locale */
     defaultLocale: string;
+    /** If using help mode, control how the help for each module should be rendered */
+    HelpComponent?: React.ComponentType<IHelpComponentProps>;
     children(props: IRootPageProps<TRootSlotType>): React.ReactNode;
     /** What should be rendered when a route doesn't exist */
     renderErrorPage(): React.ReactNode;
@@ -107,6 +110,7 @@ export class Cms<TRootSlotType extends string> extends React.Component<ICmsProps
             locale={this.props.locale}
             defaultLocale={this.props.defaultLocale}
             basePath={this.props.config.basePath}
+            HelpComponent={this.props.HelpComponent}
             renderErrorPage={this.props.renderErrorPage}
             renderErrorPlaceholder={this.props.renderErrorPlaceholder}
             renderLoadingPlaceholder={this.props.renderLoadingPlaceholder}

--- a/src/component/HelpMode.ts
+++ b/src/component/HelpMode.ts
@@ -1,0 +1,14 @@
+import { observable } from "mobx";
+
+export class HelpMode {
+    @observable
+    private active = false;
+
+    toggle() {
+        this.active = !this.active;
+    }
+
+    isActive() {
+        return this.active;
+    }
+}

--- a/src/component/IHelpComponentProps.ts
+++ b/src/component/IHelpComponentProps.ts
@@ -1,0 +1,6 @@
+import { IModule } from "../IModule";
+
+export interface IHelpComponentProps {
+    module: IModule<any, any>;
+    onRequestClose(): void;
+}

--- a/src/component/ModuleContainer.ts
+++ b/src/component/ModuleContainer.ts
@@ -1,0 +1,5 @@
+import styled from "@alethio/ui/lib/styled-components";
+
+export const ModuleContainer = styled.div`
+    position: relative;
+`;

--- a/src/component/ModuleFrame.ts
+++ b/src/component/ModuleFrame.ts
@@ -1,0 +1,24 @@
+import styled, { css } from "@alethio/ui/lib/styled-components";
+import { ModuleContainer } from "./ModuleContainer";
+
+export interface IModuleFrameProps {
+    hasHelp: boolean;
+}
+
+export const ModuleFrame = styled<IModuleFrameProps, "div">("div")`
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 100000;
+
+    ${ModuleContainer}:hover > & {
+        ${props => props.hasHelp ? css`
+            cursor: help;
+            border: 2px ${props.theme.colors.base.disabled} dashed;
+        ` : css`
+            cursor: not-allowed;
+        `}
+    }
+`;

--- a/src/component/PageRenderer.tsx
+++ b/src/component/PageRenderer.tsx
@@ -21,6 +21,11 @@ import { IPlugin } from "plugin-api/IPlugin";
 import { ILinkContext, LinkContext } from "./LinkContext";
 import { mapModuleData } from "../mapModuleData";
 import { PluginTranslationStore } from "../PluginTranslationStore";
+import { HelpMode } from "./HelpMode";
+import { observable } from "mobx";
+import { IHelpComponentProps } from "./IHelpComponentProps";
+import { ModuleContainer } from "./ModuleContainer";
+import { ModuleFrame } from "./ModuleFrame";
 
 export interface IRootPageProps<TSlotType extends string | number> {
     /** Placeholder where the CMS renders the routes (pages) */
@@ -29,6 +34,7 @@ export interface IRootPageProps<TSlotType extends string | number> {
     sidebarMobileStore: SidebarMobileStore;
     /** Placeholders for other modules that are placed at the root of the page */
     slots?: Record<TSlotType, JSX.Element[]>;
+    helpMode: HelpMode;
 }
 
 export interface IPageRendererProps<TRootSlotType extends string | number> {
@@ -40,6 +46,7 @@ export interface IPageRendererProps<TRootSlotType extends string | number> {
     locale: string;
     defaultLocale: string;
     basePath?: string;
+    HelpComponent?: React.ComponentType<IHelpComponentProps>;
     children(props: IRootPageProps<TRootSlotType>): React.ReactNode;
     renderErrorPage(): React.ReactNode;
     renderErrorPlaceholder(): JSX.Element | null;
@@ -56,11 +63,15 @@ extends React.Component<IPageRendererProps<TRootSlotType>> {
     private linkContext: ILinkContext;
     private rootContext = {};
     private toolbarUiState = {};
+    private helpMode: HelpMode;
+    @observable.ref
+    private helpOpenFor: IModule<any, any> | undefined;
 
     constructor(props: IPageRendererProps<TRootSlotType>) {
         super(props);
 
         this.sidebarMobileStore = new SidebarMobileStore();
+        this.helpMode = new HelpMode();
 
         this.linkContext = {
             pages: this.props.pages
@@ -99,7 +110,8 @@ extends React.Component<IPageRendererProps<TRootSlotType>> {
                     { this.props.children({
                         routes: this.renderPages(),
                         slots,
-                        sidebarMobileStore: this.sidebarMobileStore
+                        sidebarMobileStore: this.sidebarMobileStore,
+                        helpMode: this.helpMode
                     }) }
                 </DataContext>
             </BrowserRouter>
@@ -333,6 +345,10 @@ extends React.Component<IPageRendererProps<TRootSlotType>> {
         return !!(child as IContext<any, any>).def.create;
     }
 
+    private isModule(child: any): child is IModule<any, any> {
+        return !!(child as IModule<any, any>).def.getContentComponent;
+    }
+
     private isRefAdapterConfig(config: IDataAdapterConfig<any>): config is IDataAdapterRefConfig {
         return !!(config as IDataAdapterRefConfig).ref;
     }
@@ -379,9 +395,37 @@ extends React.Component<IPageRendererProps<TRootSlotType>> {
         let children = m.children ?
             this.renderChildren(m.children, dataLoader, context, uiStateContainer) : void 0;
 
+        let hasHelp = !!m.def.getHelpComponent;
+        let { HelpComponent } = this.props;
+
         let contentComponentPromise = m.def.getContentComponent().then(C => observer(
-            (liveProps: IContentProps<TContext, any> & ILiveContentProps) =>
-                <C {...m.def.getContentProps(liveProps)} />
+            (liveProps: IContentProps<TContext, any> & ILiveContentProps) => <>
+                { /* The container doesn't depend on observables, otherwise it would re-render the content as well */}
+                <ModuleContainer style={m.def.getWrapperStyle ? m.def.getWrapperStyle() : {}}>
+                    { /* Using observer to prevent rerendering module content when help mode is switched on/off */}
+                    <Observer>{() => this.helpMode.isActive() && !(!hasHelp && this.moduleHasAncestorWithHelp(m)) ?
+                        <ModuleFrame
+                            hasHelp={hasHelp}
+                            onClick={hasHelp ? () => this.helpOpenFor = m : void 0}
+                        /> : null
+                    }</Observer>
+                    <Observer>{() => <>
+                        { this.helpMode.isActive() && this.helpOpenFor === m && HelpComponent ?
+                        <HelpComponent module={m} onRequestClose={() => this.helpOpenFor = void 0}>
+                            <LiveData<IContentProps<TContext, any>>
+                                logger={this.props.logger}
+                                ContentComponent={Promise.resolve(observer(
+                                    m.def.getHelpComponent!() as React.ComponentType<any>
+                                ))}
+                                contentProps={liveProps}
+                                requiredAdapterTypes={[]}
+                                asyncData={new Map()}
+                            />
+                        </HelpComponent> : null }
+                    </>}</Observer>
+                    <C {...m.def.getContentProps(liveProps)} />
+                </ModuleContainer>
+            </>
         ));
 
         const getErrorPlaceholder = m.def.getErrorPlaceholder;
@@ -409,5 +453,18 @@ extends React.Component<IPageRendererProps<TRootSlotType>> {
                 options: m.options
             }}
         />;
+    }
+
+    private moduleHasAncestorWithHelp(m: IModule<any, any>) {
+        let currentNode: IModule<any, any> | IContext<any, any> = m;
+
+        while (currentNode.parent) {
+            if (this.isModule(currentNode.parent) && currentNode.parent.def.getHelpComponent) {
+                return true;
+            }
+            currentNode = currentNode.parent as IModule<any, any> | IContext<any, any>;
+        }
+
+        return false;
     }
 }

--- a/src/component/PageRenderer.tsx
+++ b/src/component/PageRenderer.tsx
@@ -401,7 +401,7 @@ extends React.Component<IPageRendererProps<TRootSlotType>> {
         let contentComponentPromise = m.def.getContentComponent().then(C => observer(
             (liveProps: IContentProps<TContext, any> & ILiveContentProps) => <>
                 { /* The container doesn't depend on observables, otherwise it would re-render the content as well */}
-                <ModuleContainer style={m.def.getWrapperStyle ? m.def.getWrapperStyle() : {}}>
+                <ModuleContainer style={m.def.getWrapperStyle ? m.def.getWrapperStyle(liveProps) : {}}>
                     { /* Using observer to prevent rerendering module content when help mode is switched on/off */}
                     <Observer>{() => this.helpMode.isActive() && !(!hasHelp && this.moduleHasAncestorWithHelp(m)) ?
                         <ModuleFrame

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,11 @@ import { SidebarMobileStore } from "./SidebarMobileStore";
 import { MenuItem } from "./component/topbar/MenuItem";
 import { MenuLayer } from "./component/topbar/MenuLayer";
 import { IInlinePlugin } from "./IInlinePlugin";
+import { HelpMode } from "./component/HelpMode";
+import { IHelpComponentProps } from "./component/IHelpComponentProps";
 
 export { Cms, Link, ExternalLink, Translation, withInternalNav, MenuItem, MenuLayer, IInlinePlugin };
+export { HelpMode, IHelpComponentProps };
 
 export { IConfigData } from "./IConfigData";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,6 +42,10 @@
             {
                 "name": "typescript-tslint-plugin",
                 "alwaysShowRuleFailuresAsWarnings": true
+            },
+            {
+                "transform": "typescript-plugin-styled-components",
+                "type": "config"
             }
         ]
     },


### PR DESCRIPTION
- Support contextual help per module by providing a toggleable "help mode" in which user can hover and click modules to see associated help.

TODO:
- [x] Use updated plugin-api dep from npm