### PR TITLE
Translation override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- New plugin config structure. New structure is an array of objects with `uri` and `config` keys. See [IPluginConfigMeta](./src/IPluginConfigMeta.ts).
+- New plugin config structure. Object map replaced with an array of objects, having at least a `uri` key, an optional `config` key and other keys such as `translations`. See [IPluginConfigMeta](./src/IPluginConfigMeta.ts).
 - Support translation overrides per plugin configuration (`translations` key)
 
 # v1.0.0-beta.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- New plugin config structure. New structure is an array of objects with `uri` and `config` keys. See [IPluginConfigMeta](./src/IPluginConfigMeta.ts).
+- Support translation overrides per plugin configuration (`translations` key)
+
 # v1.0.0-beta.8
 
 - Allow optional adapters dependencies in modules to not throw an error if the adapter is undefined.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Alethio CMS is a front-end content management system designed for real-time and 
     - [Adding plugin configuration](#adding-plugin-configuration)
     - [Configuration per module/page](#configuration-per-modulepage)
     - [Plugin localization and translation strings](#plugin-localization-and-translation-strings)
+        - [Overriding plugin translations by configuration](#overriding-plugin-translations-by-configuration)
     - [Plugin runtime API](#plugin-runtime-api)
     - [TypeScript support](#typescript-support)
     - [Linking between internal pages](#linking-between-internal-pages)
@@ -651,6 +652,26 @@ api.addModuleDef("module://my.company.tld/my-plugin/profile", {
         name: asyncData.get("adapter://my.company.tld/my-plugin/profile").data.name
     })
 });
+```
+
+#### Overriding plugin translations by configuration
+
+There are some cases where w'd like to override some translation strings from configuration, without rebuilding a plugin. We can easily do this by adding a `translations` key in the `plugins` section of the CMS config:
+
+```jsonc
+{
+    "plugins": [{
+        "uri": "plugin://my.company.tld/my-plugin?v=1.0.0",
+        "config": {
+            // ...
+        },
+        "translations": {
+            "en-US": {
+                "someKey": "My custom translation string"
+            }
+        }
+    }]
+}
 ```
 
 ### Plugin runtime API

--- a/README.md
+++ b/README.md
@@ -656,7 +656,7 @@ api.addModuleDef("module://my.company.tld/my-plugin/profile", {
 
 #### Overriding plugin translations by configuration
 
-There are some cases where w'd like to override some translation strings from configuration, without rebuilding a plugin. We can easily do this by adding a `translations` key in the `plugins` section of the CMS config:
+There are some cases where we would like to override some translation strings from configuration, without rebuilding a plugin. We can easily do this by adding a `translations` key in the `plugins` section of the CMS config:
 
 ```jsonc
 {

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ export class App extends React.Component {
             config={{
                 // We'll load the plugins from the same base URL as the app
                 "pluginsBaseUrl": "/plugins",
-                "plugins": {},
+                "plugins": [],
                 "pages": [],
                 "rootModules": {
                     // Named slot that we use in our root component to insert global modules
@@ -223,9 +223,9 @@ Finally, edit the CMS config object to enable the plugin (or the config.dev.json
 ```jsonc
 {
     // ...
-    "plugins": {
-        "plugin://<publisher>/<pluginName>": {}
-    }
+    "plugins": [{
+        "uri": "plugin://<publisher>/<pluginName>"
+    }]
     // ...
 }
 ```
@@ -549,11 +549,12 @@ hardcoding it in the plugin. We'll modify the CMS config as follows:
 
 ```json
 {
-    "plugins": {
-        "plugin://my.company.tld/my-plugin": {
+    "plugins": [{
+        "uri": "plugin://my.company.tld/my-plugin",
+        "config": {
             "profileApiUrl": "https://api.my.company.tld/profile/%d"
         }
-    }
+    }]
 }
 ```
 
@@ -996,11 +997,11 @@ Lastly, we need to add our plugin to the CMS config object:
 ```jsonc
 {
     //...
-    "plugins": {
+    "plugins": [{
         //...
-        "inline-plugin://my.company.tld/my-plugin": {}
+        "uri": "inline-plugin://my.company.tld/my-plugin"
         //...
-    }
+    }]
     //...
 }
 ```
@@ -1021,9 +1022,9 @@ This will copy the built plugins inside `dist/plugins` folder.
 
 ```jsonc
 {
-    "plugins": {
-        "plugin://my.company.tld/my-plugin?v=1.0.0": {}
-    }
+    "plugins": [{
+        "uri": "plugin://my.company.tld/my-plugin?v=1.0.0"
+    }]
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,9 +70,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.45.tgz",
-      "integrity": "sha512-tGVTbA+i3qfXsLbq9rEq/hezaHY55QxQLeXQL2ejNgFAxxrgu8eMmYIOsRcl7hN1uTLVsKOOYacV/rcJM3sfgQ==",
+      "version": "12.12.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.17.tgz",
+      "integrity": "sha512-Is+l3mcHvs47sKy+afn2O1rV4ldZFU7W8101cNlOd+MRbjM4Onida8jSZnJdTe/0Pcf25g9BNIUsuugmE6puHA==",
       "dev": true
     },
     "@types/prop-types": {
@@ -1466,9 +1466,9 @@
       }
     },
     "ttypescript": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.7.tgz",
-      "integrity": "sha512-qloW8S60+xWVC2bQWldYQfESNFkIgDL5/M+vAOOsuLJ1pQu0SG2vQx5DNJO2nlwSrHxD8cDuF2sVDXg6v3GG3Q==",
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/ttypescript/-/ttypescript-1.5.8.tgz",
+      "integrity": "sha512-uXye71UE5iPDOA3mDN9UUtconKGYwjg6m2UgnxVJYyCItE+MliSCZ4kf2asjpJsJQtgPKyu9iAaC4ero1UIbwQ==",
       "dev": true,
       "requires": {
         "resolve": "^1.9.0"
@@ -1480,9 +1480,9 @@
       "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typescript": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
-      "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
       "dev": true
     },
     "typescript-plugin-styled-components": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/Alethio/cms"
   },
   "devDependencies": {
-    "@types/node": "^8.10.18",
+    "@types/node": "^12.12.17",
     "@types/react": "^16.8.12",
     "@types/react-dom": "^16.8.3",
     "@types/react-router-dom": "^4.2.6",
@@ -38,8 +38,8 @@
     "styled-components": "^3.4.2",
     "tslib": "^1.9.3",
     "tslint": "^5.11.0",
-    "ttypescript": "^1.5.7",
-    "typescript": "^3.4.1",
+    "ttypescript": "^1.5.8",
+    "typescript": "^3.7.3",
     "typescript-plugin-styled-components": "^1.0.0",
     "typescript-styled-plugin": "^0.10.0",
     "typescript-tslint-plugin": "^0.1.0"

--- a/src/CmsConfig.ts
+++ b/src/CmsConfig.ts
@@ -1,10 +1,22 @@
 import { IConfigData } from "./IConfigData";
 import { IPluginConfigMeta } from "./IPluginConfigMeta";
+import { ILogger } from "plugin-api";
 
 export class CmsConfig {
     private data: IConfigData;
 
+    constructor(private logger: ILogger) {
+
+    }
+
     fromJson(data: IConfigData) {
+        if (!Array.isArray(data.plugins)) {
+            this.logger.warn(`Deprecation warning: The "plugins" key of the CMS config has a deprecated format.` +
+                `\nTo migrate, replace the object map with an array of objects containing ` +
+                `at least an "uri" and an optional "config" key.` +
+                `\n\nExample: [{ "uri": "plugin://my/plugin", "config": {}]`);
+        }
+
         this.data = data;
         return this;
     }

--- a/src/CmsConfig.ts
+++ b/src/CmsConfig.ts
@@ -1,4 +1,5 @@
 import { IConfigData } from "./IConfigData";
+import { IPluginConfigMeta } from "./IPluginConfigMeta";
 
 export class CmsConfig {
     private data: IConfigData;
@@ -12,19 +13,23 @@ export class CmsConfig {
         return this.data.pluginsBaseUrl;
     }
 
-    getPluginConfig(pluginUri: string) {
+    getPluginConfigMeta(pluginUri: string) {
         if (Array.isArray(this.data.plugins)) {
             let pluginConfigMeta = this.data.plugins.find(p => p.uri === pluginUri);
             if (!pluginConfigMeta) {
                 throw new Error(`Missing plugin config "${pluginUri}"`);
             }
-            return pluginConfigMeta.config || {};
+            return pluginConfigMeta;
         } else {
             // Legacy
             if (!this.data.plugins[pluginUri]) {
                 throw new Error(`Missing plugin config "${pluginUri}"`);
             }
-            return this.data.plugins[pluginUri];
+            let configMeta: IPluginConfigMeta<unknown> = {
+                uri: pluginUri,
+                config: this.data.plugins[pluginUri]
+            };
+            return configMeta;
         }
     }
 

--- a/src/CmsConfig.ts
+++ b/src/CmsConfig.ts
@@ -13,10 +13,19 @@ export class CmsConfig {
     }
 
     getPluginConfig(pluginUri: string) {
-        if (!this.data.plugins[pluginUri]) {
-            throw new Error(`Missing plugin config "${pluginUri}"`);
+        if (Array.isArray(this.data.plugins)) {
+            let pluginConfigMeta = this.data.plugins.find(p => p.uri === pluginUri);
+            if (!pluginConfigMeta) {
+                throw new Error(`Missing plugin config "${pluginUri}"`);
+            }
+            return pluginConfigMeta.config || {};
+        } else {
+            // Legacy
+            if (!this.data.plugins[pluginUri]) {
+                throw new Error(`Missing plugin config "${pluginUri}"`);
+            }
+            return this.data.plugins[pluginUri];
         }
-        return this.data.plugins[pluginUri];
     }
 
     getPluginUris() {

--- a/src/CmsConfig.ts
+++ b/src/CmsConfig.ts
@@ -46,6 +46,10 @@ export class CmsConfig {
     }
 
     getPluginUris() {
+        if (Array.isArray(this.data.plugins)) {
+            return this.data.plugins.map(plugin => plugin.uri);
+        }
+        // Legacy
         return Object.keys(this.data.plugins);
     }
 

--- a/src/IConfigData.ts
+++ b/src/IConfigData.ts
@@ -1,4 +1,5 @@
 import { IPageConfigNode } from "./PageStructureReader";
+import { IPluginConfigMeta } from "./IPluginConfigMeta";
 
 export interface IConfigData {
     /**
@@ -14,15 +15,17 @@ export interface IConfigData {
     /**
      * Specifies which plugins will be loaded, together with their specific configuration.
      *
-     * This is an object that maps pluginUri-s to plugin config objects.
-     * If a plugin has no configuration, then just pass an empty object.
+     * This is an array of objects, each containing at least an `uri` property.
      *
      * Depending on how plugins were installed (if we use an external plugin CDN/repository, or
      * if we used `acp install` without the `--dev` option),
      * the pluginUri can also contain a query string that specifies the version
      * that we want to load (e.g. `?v=1.0.0`).
+     *
+     * Legacy behavior (deprecated): This can be an object that maps pluginUri-s to plugin config objects.
+     * If a plugin has no configuration, then just pass an empty object.
      */
-    plugins: Record<string, unknown>;
+    plugins: Record<string, unknown> | IPluginConfigMeta<unknown>[];
     /**
      * A tree structure describing which pages are available, together with their descendant modules
      * See `IPageConfigNode` for the format of each node.

--- a/src/IPluginConfigMeta.ts
+++ b/src/IPluginConfigMeta.ts
@@ -1,0 +1,26 @@
+/**
+ * Plugin config meta definition
+ *
+ * Wrapper for plugin config, allowing to specify configuration keys that are not intrinsic to the plugin itself,
+ * but which are needed to configure the plugin instance within the CMS
+ * (e.g. override translations, alias entities etc.)
+ */
+export interface IPluginConfigMeta<T> {
+    /** URI for given plugin (e.g. plugin://publisher/name?v=1.0.0) */
+    uri: string;
+    /** Configuration object for given plugin */
+    config?: T;
+    /**
+     * Translation overrides, per locale
+     *
+     * Example:
+     * ```json
+     * {
+     *      "en-US": {
+     *          "myKey": "Translation string"
+     *      }
+     * }
+     * ```
+     */
+    translations?: Record<string, Record<string, string>>;
+}

--- a/src/PluginManager.ts
+++ b/src/PluginManager.ts
@@ -12,6 +12,7 @@ import { PluginValidator } from "./PluginValidator";
 import { IInlinePlugin } from "./IInlinePlugin";
 import { PageStructureValidator } from "./PageStructureValidator";
 import { version as cmsVersion } from "./version";
+import { IPluginConfigMeta } from "./IPluginConfigMeta";
 
 export class PluginManager {
     constructor(
@@ -27,12 +28,16 @@ export class PluginManager {
         let entitiesByPlugin = new Map<string, EntityCollection>();
         let allEntities = new EntityCollection();
         let pageEntityOwnerPlugins = new Map<EntityType, string>();
+        let pluginConfigMetas = new MixedCollection<string, IPluginConfigMeta<unknown>>();
 
         new PluginApiRuntime().init(window);
 
         for (let pluginUri of this.config.getPluginUris()) {
             try {
-                let pluginConfig = this.config.getPluginConfig(pluginUri);
+                let pluginConfigMeta = this.config.getPluginConfigMeta(pluginUri);
+                pluginConfigMetas.add(pluginUri, pluginConfigMeta);
+
+                let pluginConfig = pluginConfigMeta.config || {};
                 let pluginVersion = new URL(pluginUri).searchParams.get("v") || void 0;
                 this.logger.info(`Loading plugin ${pluginUri}...`);
                 pluginUri = pluginUri.split("?")[0];
@@ -80,6 +85,7 @@ export class PluginManager {
 
         let cmsRendererConfig: ICmsRendererConfig = {
             plugins,
+            pluginConfigMetas,
             pages,
             dataAdapters,
             rootModules

--- a/src/PluginTranslationStore.ts
+++ b/src/PluginTranslationStore.ts
@@ -33,7 +33,7 @@ export class PluginTranslationStore {
         loadedTranslations.forEach(([uri, translationJson]) => {
             translationJson = {
                 ...translationJson,
-                ...(this.pluginConfigMetas.get(uri).translations || {})[locale] || {}
+                ...this.pluginConfigMetas.get(uri).translations?.[locale] ?? {}
             };
             translations.add(uri, new Translation(translationJson));
         });

--- a/src/PluginTranslationStore.ts
+++ b/src/PluginTranslationStore.ts
@@ -3,6 +3,7 @@ import { MixedCollection } from "./MixedCollection";
 import { IPlugin } from "plugin-api/IPlugin";
 import { ITranslation } from "plugin-api/ITranslation";
 import { Translation } from "./Translation";
+import { IPluginConfigMeta } from "./IPluginConfigMeta";
 
 export class PluginTranslationStore {
     @observable
@@ -10,6 +11,7 @@ export class PluginTranslationStore {
 
     constructor(
         private plugins: MixedCollection<string, IPlugin>,
+        private pluginConfigMetas: MixedCollection<string, IPluginConfigMeta<unknown>>,
         private defaultLocale: string
     ) {
 
@@ -28,8 +30,12 @@ export class PluginTranslationStore {
             });
 
         let loadedTranslations = await Promise.all(translationsPromises);
-        loadedTranslations.forEach(([key, translationJson]) => {
-            translations.add(key, new Translation(translationJson));
+        loadedTranslations.forEach(([uri, translationJson]) => {
+            translationJson = {
+                ...translationJson,
+                ...(this.pluginConfigMetas.get(uri).translations || {})[locale] || {}
+            };
+            translations.add(uri, new Translation(translationJson));
         });
         this.translations = translations;
     }

--- a/src/component/Cms.tsx
+++ b/src/component/Cms.tsx
@@ -67,7 +67,7 @@ export class Cms<TRootSlotType extends string> extends React.Component<ICmsProps
     constructor(props: ICmsProps<TRootSlotType>) {
         super(props);
 
-        let cmsConfig = new CmsConfig().fromJson(this.props.config);
+        let cmsConfig = new CmsConfig(this.props.logger).fromJson(this.props.config);
         let inlinePlugins = new Map(props.inlinePlugins ?
             Object.keys(props.inlinePlugins).map(k => ([k, props.inlinePlugins![k]])) :
             []);

--- a/src/component/Cms.tsx
+++ b/src/component/Cms.tsx
@@ -102,12 +102,13 @@ export class Cms<TRootSlotType extends string> extends React.Component<ICmsProps
             return this.props.renderLoadingPlaceholder();
         }
 
-        let { dataAdapters, pages, plugins, rootModules } = this.cmsRendererConfig;
+        let { dataAdapters, pages, plugins, rootModules, pluginConfigMetas } = this.cmsRendererConfig;
 
         return <PageRenderer
             dataAdapters={dataAdapters}
             pages={pages}
             plugins={plugins}
+            pluginConfigMetas={pluginConfigMetas}
             rootModules={rootModules}
             logger={this.props.logger}
             locale={this.props.locale}

--- a/src/component/ICmsRendererConfig.ts
+++ b/src/component/ICmsRendererConfig.ts
@@ -2,9 +2,11 @@ import { MixedCollection } from "../MixedCollection";
 import { IPlugin, IDataAdapter } from "plugin-api";
 import { IPage } from "../IPage";
 import { IModule } from "../IModule";
+import { IPluginConfigMeta } from "../IPluginConfigMeta";
 
 export interface ICmsRendererConfig {
     plugins: MixedCollection<string, IPlugin>;
+    pluginConfigMetas: MixedCollection<string, IPluginConfigMeta<unknown>>;
     pages: IPage<any, any>[];
     dataAdapters: MixedCollection<string, IDataAdapter<unknown, unknown>>;
     rootModules: Record<string, IModule<any, {}>[]>;

--- a/src/component/PageRenderer.tsx
+++ b/src/component/PageRenderer.tsx
@@ -26,6 +26,7 @@ import { observable } from "mobx";
 import { IHelpComponentProps } from "./IHelpComponentProps";
 import { ModuleContainer } from "./ModuleContainer";
 import { ModuleFrame } from "./ModuleFrame";
+import { IPluginConfigMeta } from "../IPluginConfigMeta";
 
 export interface IRootPageProps<TSlotType extends string | number> {
     /** Placeholder where the CMS renders the routes (pages) */
@@ -39,6 +40,7 @@ export interface IRootPageProps<TSlotType extends string | number> {
 
 export interface IPageRendererProps<TRootSlotType extends string | number> {
     plugins: MixedCollection<string, IPlugin>;
+    pluginConfigMetas: MixedCollection<string, IPluginConfigMeta<unknown>>;
     dataAdapters: MixedCollection<string, IDataAdapter<unknown, unknown>>;
     pages: IPage<any, any>[];
     rootModules: Record<TRootSlotType, IModule<any, {}>[]>;
@@ -77,7 +79,11 @@ extends React.Component<IPageRendererProps<TRootSlotType>> {
             pages: this.props.pages
         };
 
-        this.translationStore = new PluginTranslationStore(this.props.plugins, this.props.defaultLocale);
+        this.translationStore = new PluginTranslationStore(
+            this.props.plugins,
+            this.props.pluginConfigMetas,
+            this.props.defaultLocale
+        );
 
         this.translationStore.loadTranslations(this.props.locale)
             .catch(e => this.props.logger.error(e));


### PR DESCRIPTION
- Allow plugin translation overrides via configuration
- Migrate to a more flexible config structure
```json
"plugins": [{
  "uri": "plugin://my/plugin"
}, {
  "uri": "plugin://my/plugin-with-config",
  "config": {},
  "translations": {
    "en-US": {
      "keyOverride": "Some text"
    }
  }
}]
```